### PR TITLE
fix: rename Allow-Headers header to Allow-Methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export default (options: CorsOptions) => (handler: Handler) =>
                 if (!!options.maxAge) {
                     res.headers["Access-Control-Max-Age"] = options.maxAge;
                 }
-                res.headers['Access-Control-Allow-Headers'] =
+                res.headers['Access-Control-Allow-Methods'] =
                     options.allowMethod ?
                         options.allowMethod.join(",")
                         : "GET,HEAD,PUT,PATCH,POST,DELETE";


### PR DESCRIPTION
I know this repo is old and probably maybe one cares but I couldn't stand it^^
The `Access-Control-Allow-Headers` has to be implemented as well, but that's to much for my quick fix for now sorry for that 🙏